### PR TITLE
Add figure dependencies of the final report to Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,18 @@ results/04_h0_dist.png : src/04_htest.R data/olympics_cleaned.csv
 
 # generate final report
 doc/05_final_report.html \
-doc/05_final_report.md : results/03_EDA_final_report.Rmd results/04_htest_final_report.Rmd results/05_final_report.Rmd bibliography.bib results/04_p_value.rds
+doc/05_final_report.md : results/03_EDA_final_report.Rmd \
+data/olympics_cleaned.csv \
+results/03_Figure1_age_hist.png \
+results/03_Figure2_numeric_cols_plot.png \
+results/03_Figure3_numeric_cols_plot.png \
+results/03_Figure4_age_medals_hist.png \
+results/04_htest_final_report.Rmd \
+results/04_h0_dist.png \
+results/05_final_report.Rmd \
+bibliography.bib \
+results/04_p_value.rds \
+results/04_summary.rds
 	Rscript -e "rmarkdown::render('results/05_final_report.Rmd', 'all', output_dir='doc')"
 	
 clean :


### PR DESCRIPTION
I have found an issue with the Makefile when I did some testing.

I tried to randomly delete some files and see if Makefile would behave correctly.  I notice that the Makefile, without the figure and some other files added to the final report, the Makefile would not try to rebuild the figures, etc., and the report generation would fail.

So I have changed the Makefile and tested that already.  Please try it on your computers.  Try to randomly delete some of the generated files and see whether this new Makefile works correctly for you.